### PR TITLE
Adds optional virtualenv directory parameter

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -19,7 +19,7 @@ test('get python version', async () => {
 })
 
 test('get virtualenv directory', async () => {
-  expect(await utils.virtualenv_directory()).toContain('.venv')
+  expect(await utils.virtualenv_directory('venv-custom')).toContain('venv-custom')
 })
 
 test('get hash for file glob', async () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -19,7 +19,9 @@ test('get python version', async () => {
 })
 
 test('get virtualenv directory', async () => {
-  expect(await utils.virtualenv_directory('venv-custom')).toContain('venv-custom')
+  expect(await utils.virtualenv_directory('venv-custom')).toContain(
+    'venv-custom'
+  )
 })
 
 test('get hash for file glob', async () => {

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
         **/Pipfile.lock
         **/poetry.lock
 
+  custom_virtualenv_dir:
+    required: false
+    description: "custom directory for the virtual environment"
+    default: ".venv"
+
 outputs:
   cache-hit:
     description: "A boolean value to indicate if a cache was restored"

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -12,8 +12,11 @@ async function run(): Promise<void> {
     const custom_cache_key = core.getInput('custom_cache_key_element', {
       required: true
     })
+    const custom_virtualenv_dir = core.getInput('custom_virtualenv_dir', {
+      required: true
+    })
 
-    const virtualenv_dir = await utils.virtualenv_directory()
+    const virtualenv_dir = await utils.virtualenv_directory(custom_virtualenv_dir)
     core.saveState('VIRTUALENV_DIRECTORY', virtualenv_dir)
     core.setOutput('virtualenv-directory', virtualenv_dir)
 

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -16,7 +16,9 @@ async function run(): Promise<void> {
       required: true
     })
 
-    const virtualenv_dir = await utils.virtualenv_directory(custom_virtualenv_dir)
+    const virtualenv_dir = await utils.virtualenv_directory(
+      custom_virtualenv_dir
+    )
     core.saveState('VIRTUALENV_DIRECTORY', virtualenv_dir)
     core.setOutput('virtualenv-directory', virtualenv_dir)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,9 @@ export async function cache_key(
   return `${base}-${hash}`
 }
 
-export async function virtualenv_directory(): Promise<string> {
+export async function virtualenv_directory(
+  custom_virtualenv_dir: string
+): Promise<string> {
   let home = ''
   if (process.platform === 'win32') {
     home = `${process.env['HOMEDRIVE']}${process.env['HOMEPATH']}`
@@ -49,7 +51,7 @@ export async function virtualenv_directory(): Promise<string> {
   const virtualenv_base = `${home}${path.sep}.virtualenvs`
   await io.mkdirP(virtualenv_base)
 
-  return `${virtualenv_base}${path.sep}.venv`
+  return `${virtualenv_base}${path.sep}${custom_virtualenv_dir}`
 }
 
 export function logWarning(message: string): void {


### PR DESCRIPTION
Replace fixed `.venv` directory with optional input parameter.

Related issues:
https://github.com/syphar/restore-virtualenv/issues/213
https://github.com/syphar/restore-virtualenv/issues/156